### PR TITLE
Changed return text for ETIMEDOUT/ WSAETIMEDOUT

### DIFF
--- a/src/pierror.h
+++ b/src/pierror.h
@@ -12,7 +12,7 @@
 #define PIE_CONNREFUSED    "connection refused"
 #define PIE_CONNABORTED    "closed"
 #define PIE_CONNRESET      "closed"
-#define PIE_TIMEDOUT       "timeout"
+#define PIE_TIMEDOUT       "connection timeout"
 #define PIE_AGAIN          "temporary failure in name resolution"
 #define PIE_BADFLAGS       "invalid value for ai_flags"
 #define PIE_BADHINTS       "invalid value for hints"


### PR DESCRIPTION
Changed return text for ETIMEDOUT/ WSAETIMEDOUT to “connection timeout”.

This is needed for the application to be able tell to the difference between timeout of TCP connection (ETIMEDOUT/ WSAETIMEDOUT) and a normal return from a non-blocking socket (error codes EAGAIN/WSAEWOULDBLOCK). Both situations returned the text “timeout”.
